### PR TITLE
Add VLLM support for generating textual outputs

### DIFF
--- a/batched_lm_generation/vllm_base.py
+++ b/batched_lm_generation/vllm_base.py
@@ -1,0 +1,97 @@
+"""
+Generates completions from a base model using VLLM. This code is adapted from
+the automodel_base.py to utilize VLLM for generating textual outputs.
+
+"""
+
+from .base import GeneratorBase, partial_arg_parser, stop_at_stop_token
+from vllm import LLM, SamplingParams
+from typing import List
+import torch
+import itertools
+import json
+
+
+class VLLMGenerator(GeneratorBase):
+    model_name: str
+    model_kwargs: dict
+    model: LLM
+
+    def __init__(
+        self, model_name: str, include_prompt: str, num_gpus: int, model_kwargs, **super_args
+    ):
+        super().__init__(**super_args)
+        self.model_name = model_name
+        self.model_kwargs = model_kwargs
+        self.include_prompt = include_prompt
+
+    def init_model(self):
+        self.model = LLM(
+            model=self.model_name,
+            tokenizer=self.model_name,
+            dtype=torch.bfloat16,
+            max_model_len=2048,
+            trust_remote_code=True,
+            tensor_parallel_size=num_gpus,
+            gpu_memory_utilization=0.95,
+        )
+
+    def batch_generate(
+        self,
+        prompts: List[str],
+        top_p: float,
+        temperature: float,
+        max_tokens: int,
+        stop: List[str],
+    ) -> List[str]:
+        prompts = [prompt.strip() for prompt in prompts]
+        params = SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            stop=stop
+        )
+
+        outputs = self.model.generate(prompts, params, use_tqdm=False)
+        if self.include_prompt:
+            outputs = [prompt + text for prompt, text in zip(prompts, outputs)]
+        return outputs
+
+
+def main():
+    parser = partial_arg_parser()
+    parser.add_argument("--model-name", type=str, required=True)
+    parser.add_argument(
+        "--include-prompt",
+        action="store_true",
+        help="Includes the prompt in the stored completions",
+    )
+    parser.add_argument("--revision", type=str)
+    parser.add_argument("--tokenizer-revision", type=str)
+    parser.add_argument("--num-gpus", type=int, default=1)
+    parser.add_argument(
+        "--stop", type=str, required=True, help="JSON list of stop tokens"
+    )
+    args = parser.parse_args()
+    args.stop = json.loads(args.stop)
+
+    model_kwargs = {
+        "revision": args.revision,
+        "tokenizer_revision": args.tokenizer_revision,
+        "num_gpus": args.num_gpus
+    }
+
+    super_args = {
+        k: v
+        for (k, v) in vars(args).items()
+        if k not in ["model_name", "revision", "tokenizer_revision", "num_gpus", "include_prompt"]
+    }
+
+    generator = VLLMGenerator(
+        args.model_name, args.include_prompt, args.num_gpus, model_kwargs, **super_args
+    )
+    generator.generate_all()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Related to #1

This PR introduces a new file `vllm_base.py` to the `batched_lm_generation` module, enabling text generation using the VLLM library instead of Transformers. 

- **Implements VLLM Integration:** Adapts code from `automodel_base.py` to use VLLM's `LLM` and `SamplingParams` for generating textual outputs. This includes initializing the `LLM` model with parameters such as model name, tokenizer, and GPU settings.
- **Batch Generation Support:** Updates the `batch_generate` method to utilize VLLM's generate method with specified sampling parameters, allowing for batch processing of text generation requests.
- **Command Line Interface:** Extends the existing CLI with additional arguments to support VLLM-specific configurations such as model name, inclusion of prompts in outputs, and stop tokens.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/arjunguha/batched_lm_generation/issues/1?shareId=e0f7009e-80dd-4d50-b8c8-2bf28ab5f02c).