### PR TITLE
Fix batch count issue in batch prompts

### DIFF
--- a/batched_lm_generation/base.py
+++ b/batched_lm_generation/base.py
@@ -131,17 +131,17 @@ def _batch_prompts(
             yield batch
             batch = []
             batch_count = 0
-        if prompt.count + batch_count > batch_size:
+        while prompt.count + batch_count > batch_size:
             # We need to split the prompt across batches.
             take_count = batch_size - batch_count
             drop_count = prompt.count - take_count
             batch.append(PromptPathCount(prompt.prompt, prompt.path, take_count))
             yield batch
-            batch = [PromptPathCount(prompt.prompt, prompt.path, drop_count)]
-            batch_count = drop_count
-        else:
-            batch.append(prompt)
-            batch_count += prompt.count
+            batch = []
+            batch_count = 0
+            prompt = PromptPathCount(prompt.prompt, prompt.path, drop_count)
+        batch.append(prompt)
+        batch_count += prompt.count
 
     if len(batch) > 0:
         yield batch


### PR DESCRIPTION
Related to #9

Updates the `_batch_prompts` function in `batched_lm_generation/base.py` to correctly handle cases where `drop_count` exceeds `batch_size`, ensuring that no single batch exceeds the specified `batch_size`.

- Modifies the loop within `_batch_prompts` to iteratively check if adding a `prompt.count` to the current `batch_count` would exceed `batch_size`. If so, it splits the `PromptPathCount` across multiple batches as needed, ensuring each batch adheres to the `batch_size` limit.
- Adjusts the logic to reset `batch` and `batch_count` after yielding a batch, facilitating the creation of new batches for any remaining `drop_count` that exceeds the `batch_size`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/arjunguha/batched_lm_generation/issues/9?shareId=d3b1db87-cf8e-4b72-bf0d-e4135e0b0050).